### PR TITLE
Remove prefix of room name in mesh/sfu examples

### DIFF
--- a/examples/mesh-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_mesh_textchat/MainActivity.java
+++ b/examples/mesh-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_mesh_textchat/MainActivity.java
@@ -193,7 +193,7 @@ public class MainActivity extends Activity {
 		option.mode = RoomOption.RoomModeEnum.MESH;
 
 		// Join Room
-		_room = _peer.joinRoom("mesh_text_" + roomName, option);
+		_room = _peer.joinRoom(roomName, option);
 		_bConnected = true;
 
 		//

--- a/examples/mesh-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_mesh_videochat/MainActivity.java
+++ b/examples/mesh-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_mesh_videochat/MainActivity.java
@@ -302,7 +302,7 @@ public class MainActivity extends Activity {
 		option.stream = _localStream;
 
 		// Join Room
-		_room = _peer.joinRoom("mesh_video_" + roomName, option);
+		_room = _peer.joinRoom(roomName, option);
 		_bConnected = true;
 
 		//

--- a/examples/sfu-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_sfu_textchat/MainActivity.java
+++ b/examples/sfu-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_sfu_textchat/MainActivity.java
@@ -192,7 +192,7 @@ public class MainActivity extends Activity {
 		option.mode = RoomOption.RoomModeEnum.SFU;
 
 		// Join Room
-		_room = _peer.joinRoom("sfu_text_" + roomName, option);
+		_room = _peer.joinRoom(roomName, option);
 		_bConnected = true;
 
 		//

--- a/examples/sfu-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_sfu_videochat/MainActivity.java
+++ b/examples/sfu-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_sfu_videochat/MainActivity.java
@@ -302,7 +302,7 @@ public class MainActivity extends Activity {
 		option.stream = _localStream;
 
 		// Join Room
-		_room = _peer.joinRoom("sfu_video_" + roomName, option);
+		_room = _peer.joinRoom(roomName, option);
 		_bConnected = true;
 
 		//


### PR DESCRIPTION
[Background]
- In mesh/sfu room examples, android SDK examples have the room name with the prefix.
To connect android SDK examples with [new JS SDK examples](https://github.com/skyway/skyway-js-sdk/tree/master/examples/room), JS SDK example's room name must add the prefix. (eg. `mesh_video_{roomname}`)

In this PR,  above are fixed.

[After]
In mesh/sfu room example, android SDK examples and new JS SDK examples can connect completely same room name.