### PR TITLE
Fixed window flag usage in p2p-videochat

### DIFF
--- a/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
+++ b/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
@@ -63,8 +63,6 @@ public class MainActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		Window wnd = getWindow();
-		wnd.addFlags(Window.FEATURE_NO_TITLE);
 		setContentView(R.layout.activity_main);
 
 		_handler = new Handler(Looper.getMainLooper());
@@ -210,6 +208,13 @@ public class MainActivity extends Activity {
 	@Override
 	protected void onStart() {
 		super.onStart();
+
+		// @See: https://developer.android.com/training/system-ui/status#41
+		// Hide the status bar.
+		window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
+		// Remember that you should never show the action bar if the
+		// status bar is hidden, so hide that too if necessary.
+		actionBar?.hide()
 
 		// Disable Sleep and Screen Lock
 		Window wnd = getWindow();

--- a/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
+++ b/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
@@ -1,6 +1,7 @@
 package com.ntt.ecl.webrtc.sample_p2p_videochat;
 
 import android.Manifest;
+import android.app.ActionBar;
 import android.app.Activity;
 import android.app.FragmentManager;
 import android.content.Context;
@@ -209,17 +210,24 @@ public class MainActivity extends Activity {
 	protected void onStart() {
 		super.onStart();
 
+		Window window = getWindow();
+		View decorView = getWindow().getDecorView();
+
 		// @See: https://developer.android.com/training/system-ui/status#41
 		// Hide the status bar.
-		window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_FULLSCREEN
+		int uiOptions = View.SYSTEM_UI_FLAG_FULLSCREEN;
+		decorView.setSystemUiVisibility(uiOptions);
+
 		// Remember that you should never show the action bar if the
 		// status bar is hidden, so hide that too if necessary.
-		actionBar?.hide()
+		ActionBar actionBar = getActionBar();
+		if (actionBar != null) {
+			actionBar.hide();
+		}
 
 		// Disable Sleep and Screen Lock
-		Window wnd = getWindow();
-		wnd.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
-		wnd.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+		window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 	}
 
 	@Override


### PR DESCRIPTION
I found to take mistake Window.FEATURE_NO_TITLE in p2p-videochat example. Originally you should use Activity#requestFeature.

In the current example, FLAG_ALLOW_LOCK_WHILE_SCREEN_ON is specified.
because Window.FEATURE_NO_TITLE is the same bit as WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON.

As a result, the lock screen is enabled even if the flag is specified.
See: https://github.com/skyway/skyway-android-sdk/blob/master/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java#L216-L217

I fixed to hide the Status Bar on Android 4.1 and Higher.