### PR TITLE
Release v2.1.0

### DIFF
--- a/examples/p2p-call/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_call/MainActivity.java
+++ b/examples/p2p-call/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_call/MainActivity.java
@@ -199,8 +199,8 @@ public class MainActivity extends Activity {
 
 					// Hang up a call
 					closeRemoteStream();
-					_mediaConnection.close();
-					_signalingChannel.close();
+					_mediaConnection.close(true);
+					_signalingChannel.close(true);
 					_callState = CallState.TERMINATED;
 					updateActionButtonTitle();
 
@@ -320,7 +320,7 @@ public class MainActivity extends Activity {
 			@Override
 			public void onCallback(Object object) {
 				closeRemoteStream();
-				_signalingChannel.close();
+				_signalingChannel.close(true);
 				_callState = CallState.TERMINATED;
 				updateActionButtonTitle();
 			}
@@ -371,13 +371,13 @@ public class MainActivity extends Activity {
 				switch(message) {
 					case "reject":
 						closeMediaConnection();
-						_signalingChannel.close();
+						_signalingChannel.close(true);
 						_callState = CallState.TERMINATED;
 						updateActionButtonTitle();
 						break;
 					case "cancel":
 						closeMediaConnection();
-						_signalingChannel.close();
+						_signalingChannel.close(true);
 						_callState = CallState.TERMINATED;
 						updateActionButtonTitle();
 						dismissIncomingCallDialog();
@@ -453,7 +453,7 @@ public class MainActivity extends Activity {
 	void closeMediaConnection() {
 		if (null != _mediaConnection)	{
 			if (_mediaConnection.isOpen()) {
-				_mediaConnection.close();
+				_mediaConnection.close(true);
 			}
 			unsetMediaCallbacks();
 		}
@@ -481,7 +481,7 @@ public class MainActivity extends Activity {
 		}
 
 		if (null != _mediaConnection) {
-			_mediaConnection.close();
+			_mediaConnection.close(true);
 		}
 
 		CallOption option = new CallOption();

--- a/examples/p2p-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_textchat/MainActivity.java
+++ b/examples/p2p-textchat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_textchat/MainActivity.java
@@ -147,7 +147,7 @@ public class MainActivity extends Activity {
 				}
 				else {
 					// Hang up a connection
-					_dataConnection.close();
+					_dataConnection.close(true);
 				}
 
 				v.setEnabled(true);
@@ -317,7 +317,7 @@ public class MainActivity extends Activity {
 	private void destroyPeer() {
 		if (null != _dataConnection)	{
 			if (_dataConnection.isOpen()) {
-				_dataConnection.close();
+				_dataConnection.close(true);
 			}
 			unsetDataCallbacks();
 		}
@@ -376,7 +376,7 @@ public class MainActivity extends Activity {
 		}
 
 		if (null != _dataConnection) {
-			_dataConnection.close();
+			_dataConnection.close(true);
 		}
 
 		ConnectOption option = new ConnectOption();

--- a/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
+++ b/examples/p2p-videochat/app/src/main/java/com/ntt/ecl/webrtc/sample_p2p_videochat/MainActivity.java
@@ -163,7 +163,7 @@ public class MainActivity extends Activity {
 
 					// Hang up a call
 					closeRemoteStream();
-					_mediaConnection.close();
+					_mediaConnection.close(true);
 
 				}
 
@@ -308,7 +308,7 @@ public class MainActivity extends Activity {
 
 		if (null != _mediaConnection)	{
 			if (_mediaConnection.isOpen()) {
-				_mediaConnection.close();
+				_mediaConnection.close(true);
 			}
 			unsetMediaCallbacks();
 		}
@@ -380,7 +380,7 @@ public class MainActivity extends Activity {
 		}
 
 		if (null != _mediaConnection) {
-			_mediaConnection.close();
+			_mediaConnection.close(true);
 		}
 
 		CallOption option = new CallOption();

--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,6 +2,14 @@
 
 [日本語](./release-notes.md)
 
+## [Version 2.1.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.1.0)
+
+### Added
+- Add an `forceClose` option when calling `Connection.close` to signal intention to disconnection to the remote peer instantly.
+
+### Deprecated
+- The `false` default value of `forceClose` is deprecated and may be changed to `true` in future versions.
+
 ## [Version 2.0.4](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.0.4)
 
 ### Fixed

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,14 @@
 
 [English](./release-notes.en.md)
 
+## [Version 2.1.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.1.0)
+
+### Added
+- `Connection.close` に `forceClose` オプションを追加しました。このオプションを有効にすると、接続相手においても `Connection` が即座にクローズします。
+
+### Deprecated
+- `forceClose` のデフォルト値 `false` は将来のバージョンでは `true` に変更される可能性があります。
+
 ## [Version 2.0.4](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.0.4)
 
 ### Fixed


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Feature

### Summary
- Add an `forceClose` option when calling `Connection.close` to signal intention to disconnection to the remote peer instantly.
- The `false` default value of `forceClose` is deprecated and may be changed to `true` in future versions.
- Add forceClose option to examples

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
