### PR TITLE
Release v2.2.0

### DIFF
--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,6 +2,12 @@
 
 [日本語](./release-notes.md)
 
+## [Version 2.2.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.2.0) - 2020-11-16
+
+### Added
+
+- Added `tryReconnectMedia` and `tryReconnectData` option to `PeerOption`. This enables to try to reconnect automatically when the WebRTC communication state is temporarily disconnected due to unstable communication or other reasons. The default value is false.
+
 ## [Version 2.1.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.1.0) - 2020-11-10
 
 ### Added
@@ -32,7 +38,7 @@
 
 ### Fixed
 
-- Fixed a crash when verifying a TLS server certificate on certain devices. 
+- Fixed a crash when verifying a TLS server certificate on certain devices.
 
 ## [Version 2.0.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.0.0) - 2020-06-09
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,12 @@
 
 [English](./release-notes.en.md)
 
+## [Version 2.2.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.2.0) - 2020-11-16
+
+### Added
+
+- Peer オプションに `tryReconnectMedia` と `tryReconnectData` のオプションを追加しました。このオプションを有効にすることで、WebRTC通信が一時的な切断状態になった場合に自動再接続を試行するようになります。デフォルトではこのオプションは無効です。
+
 ## [Version 2.1.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.1.0) - 2020-11-10
 
 ### Added
@@ -33,7 +39,7 @@
 
 ### Fixed
 
-- 特定の端末でTLS サーバー証明書の検証時にクラッシュする不具合を修正しました。  
+- 特定の端末でTLS サーバー証明書の検証時にクラッシュする不具合を修正しました。
 
 ## [Version 2.0.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.0.0) - 2020-06-09
 


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Documentation content changes

### Summary

Updated release notes for v2.2.0.

Added `tryReconnectMedia` and `tryReconnectData` option to `PeerOption`. This enables to try to reconnect automatically when the WebRTC communication state is temporarily disconnected due to unstable communication or other reasons. The default value is false.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
