### PR TITLE
Release v2.3.0

### DIFF
--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,6 +2,12 @@
 
 [日本語](./release-notes.md)
 
+## [Version 2.3.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.3.0) - 2020-12-22
+
+### Added
+
+- Added `fetchPeerExists` API to fetch whether a peer exists. You can call this API once per second per peer.
+
 ## [Version 2.2.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.2.0) - 2020-11-16
 
 ### Added

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,12 @@
 
 [English](./release-notes.en.md)
 
+## [Version 2.3.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.3.0) - 2020-12-22
+
+### Added
+
+- Peerの存在を確認することができる `fetchPeerExists` メソッドを追加しました。1秒に1回利用することが可能です。
+
 ## [Version 2.2.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.2.0) - 2020-11-16
 
 ### Added


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Documentation content changes

### Summary

Updated release notes for v2.3.0.

Added `fetchPeerExists` API to fetch whether a peer exists. You can call this API once per second per peer.
### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
