### PR TITLE
Release v2.4.0

### DIFF
--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,6 +2,12 @@
 
 [日本語](./release-notes.md)
 
+## [Version 2.4.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.4.0) - 2021-01-19
+
+### Fixed
+
+- Fixed a connecting process to signaling server so that `Peer` would reconnect when a request to the dispatcher server failed.
+
 ## [Version 2.3.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.3.0) - 2020-12-22
 
 ### Added

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,12 @@
 
 [English](./release-notes.en.md)
 
+## [Version 2.4.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.4.0) - 2021-01-19
+
+### Fixed
+
+- シグナリングサーバへの接続プロセスを修正し、`Peer` からディスパッチャーサーバへのリクエストが失敗した場合に再接続するようにしました。
+
 ## [Version 2.3.0](https://github.com/skyway/skyway-android-sdk/releases/tag/v2.3.0) - 2020-12-22
 
 ### Added


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Documentation content changes

### Summary
Updated release notes for v2.4.0.

Fixed a connecting process to signaling server so that `Peer` would reconnect when a request to the dispatcher server failed.

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
